### PR TITLE
sa-notify: Add sa-notify plugin

### DIFF
--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -85,6 +85,7 @@ plugins = \
 	plugins/random.opt \
 	plugins/resolve.opt \
 	plugins/revocation.opt \
+	plugins/sa-notify.opt \
 	plugins/save-keys.opt \
 	plugins/socket-default.opt \
 	plugins/sql.opt \

--- a/conf/plugins/sa-notify.opt
+++ b/conf/plugins/sa-notify.opt
@@ -1,0 +1,5 @@
+charon.plugins.sa-notify.load := no
+	Whether to load the plugin.
+
+charon.plugins.sa-notify.child_sa
+	File where the CHILD_SA events are written to.

--- a/configure.ac
+++ b/configure.ac
@@ -272,6 +272,7 @@ ARG_ENABL_SET([led],            [enable plugin to control LEDs on IKEv2 activity
 ARG_ENABL_SET([load-tester],    [enable load testing plugin for IKEv2 daemon.])
 ARG_ENABL_SET([lookip],         [enable fast virtual IP lookup and notification plugin.])
 ARG_ENABL_SET([radattr],        [enable plugin to inject and process custom RADIUS attributes as IKEv2 client.])
+ARG_ENABL_SET([sa-notify],      [enable plugin to write CHILD_SA events to a file.])
 ARG_ENABL_SET([save-keys],      [enable development/debugging plugin that saves IKE and ESP keys in Wireshark format.])
 ARG_ENABL_SET([systime-fix],    [enable plugin to handle cert lifetimes with invalid system time gracefully.])
 ARG_ENABL_SET([test-vectors],   [enable plugin providing crypto test vectors.])
@@ -1442,6 +1443,7 @@ ADD_PLUGIN([kernel-pfkey],         [c charon starter nm cmd])
 ADD_PLUGIN([kernel-pfroute],       [c charon starter nm cmd])
 ADD_PLUGIN([kernel-netlink],       [c charon starter nm cmd])
 ADD_PLUGIN([resolve],              [c charon cmd])
+ADD_PLUGIN([sa-notify],            [c])
 ADD_PLUGIN([save-keys],            [c])
 ADD_PLUGIN([socket-default],       [c charon nm cmd])
 ADD_PLUGIN([socket-dynamic],       [c charon cmd])
@@ -1671,6 +1673,7 @@ AM_CONDITIONAL(USE_IMC_SWIMA, test x$imc_swima = xtrue)
 AM_CONDITIONAL(USE_IMV_SWIMA, test x$imv_swima = xtrue)
 AM_CONDITIONAL(USE_IMC_HCD, test x$imc_hcd = xtrue)
 AM_CONDITIONAL(USE_IMV_HCD, test x$imv_hcd = xtrue)
+AM_CONDITIONAL(USE_SA_NOTIFY, test x$sa_notify = xtrue)
 AM_CONDITIONAL(USE_SAVE_KEYS, test x$save_keys = xtrue)
 AM_CONDITIONAL(USE_SOCKET_DEFAULT, test x$socket_default = xtrue)
 AM_CONDITIONAL(USE_SOCKET_DYNAMIC, test x$socket_dynamic = xtrue)
@@ -1935,6 +1938,7 @@ AC_CONFIG_FILES([
 	src/libcharon/plugins/xauth_noauth/Makefile
 	src/libcharon/plugins/tnc_ifmap/Makefile
 	src/libcharon/plugins/tnc_pdp/Makefile
+	src/libcharon/plugins/sa_notify/Makefile
 	src/libcharon/plugins/save_keys/Makefile
 	src/libcharon/plugins/socket_default/Makefile
 	src/libcharon/plugins/socket_dynamic/Makefile

--- a/src/libcharon/Makefile.am
+++ b/src/libcharon/Makefile.am
@@ -208,6 +208,13 @@ if MONOLITHIC
 endif
 endif
 
+if USE_SA_NOTIFY
+ SUBDIRS += plugins/sa_notify
+if MONOLITHIC
+ libcharon_la_LIBADD += plugins/sa_notify/libstrongswan-sa-notify.la
+endif
+endif
+
 if USE_SAVE_KEYS
  SUBDIRS += plugins/save_keys
 if MONOLITHIC

--- a/src/libcharon/plugins/sa_notify/Makefile.am
+++ b/src/libcharon/plugins/sa_notify/Makefile.am
@@ -1,0 +1,16 @@
+AM_CPPFLAGS = \
+	-I$(top_srcdir)/src/libstrongswan \
+	-I$(top_srcdir)/src/libcharon
+AM_CFLAGS = \
+	$(PLUGIN_CFLAGS)
+
+if MONOLITHIC
+noinst_LTLIBRARIES = libstrongswan-sa-notify.la
+else
+plugin_LTLIBRARIES = libstrongswan-sa-notify.la
+endif
+
+libstrongswan_sa_notify_la_SOURCES = \
+	sa_notify_plugin.h sa_notify_plugin.c \
+	sa_notify_listener.h sa_notify_listener.c
+libstrongswan_sa_notify_la_LDFLAGS = -module -avoid-version

--- a/src/libcharon/plugins/sa_notify/sa_notify_listener.c
+++ b/src/libcharon/plugins/sa_notify/sa_notify_listener.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2018 Christopher Chon
+ * Nefeli Networks Inc.
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#define _GNU_SOURCE
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "sa_notify_listener.h"
+
+#include <daemon.h>
+
+typedef struct private_sa_notify_listener_t private_sa_notify_listener_t;
+typedef struct algo_map_t algo_map_t;
+
+/**
+ * CHILD_SA creation
+ */
+static const char *CREATE = "CREATE";
+
+/**
+ * CHILD_SA deletion
+ */
+static const char *DELETE = "DELETE";
+
+/**
+ * CHILD_SA rekey
+ */
+static const char *REKEY = "REKEY";
+
+/**
+ * Private data
+ */
+struct private_sa_notify_listener_t {
+
+  /**
+   * Public interface
+   */
+  sa_notify_listener_t public;
+
+  /**
+   * File path to where SAs will be written
+   */
+  char *filepath;
+
+  /**
+   * File
+   */
+  FILE *f;
+};
+
+/**
+ * Mapping strongSwan identifiers to Wireshark names
+ */
+struct algo_map_t {
+
+  /**
+   * IKE identifier
+   */
+  const uint16_t ike;
+
+  /**
+   * Optional key length
+   */
+  const int key_len;
+
+  /**
+   * Name of the algorithm in wireshark
+   */
+  const char *name;
+};
+
+/**
+ * Map an algorithm identifier to a name
+ */
+static inline const char *algo_name(algo_map_t *map, int count, uint16_t alg,
+                                    int key_len) {
+  int i;
+  for (i = 0; i < count; i++) {
+    if (map[i].ike == alg) {
+      if (map[i].key_len == -1 || map[i].key_len == key_len) {
+        return map[i].name;
+      }
+    }
+  }
+  return NULL;
+}
+
+/**
+ * Wireshark ESP algorithm identifiers for encryption
+ */
+static algo_map_t esp_encr[] = {
+    {ENCR_NULL, -1, "NULL"},
+    {ENCR_3DES, -1, "TripleDes-CBC [RFC2451]"},
+    {ENCR_AES_CBC, -1, "AES-CBC [RFC3602]"},
+    {ENCR_AES_CTR, -1, "AES-CTR [RFC3686]"},
+    {ENCR_DES, -1, "DES-CBC [RFC2405]"},
+    {ENCR_CAST, -1, "CAST5-CBC [RFC2144]"},
+    {ENCR_BLOWFISH, -1, "BLOWFISH-CBC [RFC2451]"},
+    {ENCR_TWOFISH_CBC, -1, "TWOFISH-CBC"},
+    {ENCR_AES_GCM_ICV8, -1, "AES-GCM [RFC4106]"},
+    {ENCR_AES_GCM_ICV12, -1, "AES-GCM [RFC4106]"},
+    {ENCR_AES_GCM_ICV16, -1, "AES-GCM [RFC4106]"},
+};
+
+/**
+ * Wireshark ESP algorithms for integrity
+ */
+static algo_map_t esp_integ[] = {
+    {AUTH_HMAC_SHA1_96, -1, "HMAC-SHA-1-96 [RFC2404]"},
+    {AUTH_HMAC_MD5_96, -1, "HMAC-MD5-96 [RFC2403]"},
+    {AUTH_HMAC_SHA2_256_128, -1, "HMAC-SHA-256-128 [RFC4868]"},
+    {AUTH_HMAC_SHA2_384_192, -1, "HMAC-SHA-384-192 [RFC4868]"},
+    {AUTH_HMAC_SHA2_512_256, -1, "HMAC-SHA-512-256 [RFC4868]"},
+    {AUTH_HMAC_SHA2_256_96, -1,
+     "HMAC-SHA-256-96 [draft-ietf-ipsec-ciph-sha-256-00]"},
+    {AUTH_UNDEFINED, 64, "ANY 64 bit authentication [no checking]"},
+    {AUTH_UNDEFINED, 96, "ANY 96 bit authentication [no checking]"},
+    {AUTH_UNDEFINED, 128, "ANY 128 bit authentication [no checking]"},
+    {AUTH_UNDEFINED, 192, "ANY 192 bit authentication [no checking]"},
+    {AUTH_UNDEFINED, 256, "ANY 256 bit authentication [no checking]"},
+    {AUTH_UNDEFINED, -1, "NULL"},
+};
+
+/**
+ * Map an ESP proposal
+ */
+static inline void esp_names(proposal_t *proposal, const char **enc,
+                             const char **integ) {
+  uint16_t alg, len;
+
+  if (proposal->get_algorithm(proposal, ENCRYPTION_ALGORITHM, &alg, &len)) {
+    *enc = algo_name(esp_encr, countof(esp_encr), alg, len);
+  }
+  len = -1;
+  if (!proposal->get_algorithm(proposal, INTEGRITY_ALGORITHM, &alg, NULL)) {
+    switch (alg) {
+    case ENCR_AES_GCM_ICV8:
+      len = 64;
+      break;
+    case ENCR_AES_GCM_ICV12:
+      len = 64;
+      break;
+    case ENCR_AES_GCM_ICV16:
+      len = 128;
+      break;
+    }
+    alg = AUTH_UNDEFINED;
+  }
+  *integ = algo_name(esp_integ, countof(esp_integ), alg, len);
+}
+
+/**
+ * Handle CHILD SA creation
+ * Based on the save-keys plugin
+ */
+METHOD(listener_t, child_derived_keys, bool, private_sa_notify_listener_t *this,
+       ike_sa_t *ike_sa, child_sa_t *child_sa, bool initiator, chunk_t encr_i,
+       chunk_t encr_r, chunk_t integ_i, chunk_t integ_r) {
+  if (child_sa->get_protocol(child_sa) != PROTO_ESP) {
+    return TRUE;
+  }
+
+  host_t *init, *resp;
+  uint32_t spi_i, spi_r;
+  const char *enc = NULL, *integ = NULL;
+  char *family;
+  esp_names(child_sa->get_proposal(child_sa), &enc, &integ);
+  uint32_t uid = child_sa->get_unique_id(child_sa);
+  if (enc && integ) {
+    /* Since the IPs are printed this is not compatible with MOBIKE */
+    if (initiator) {
+      init = ike_sa->get_my_host(ike_sa);
+      resp = ike_sa->get_other_host(ike_sa);
+    } else {
+      init = ike_sa->get_other_host(ike_sa);
+      resp = ike_sa->get_my_host(ike_sa);
+    }
+    spi_i = child_sa->get_spi(child_sa, initiator);
+    spi_r = child_sa->get_spi(child_sa, !initiator);
+    family = init->get_family(init) == AF_INET ? "IPv4" : "IPv6";
+
+    /* a CHILD_SA consists of a pair of SAs */
+    int res1 = fprintf(this->f,
+				"\"%s\",\"%u\",\"%s\",\"%H\",\"%H\",\"0x%.8x\","
+				"\"%s\",\"0x%+B\",\"%s\",\"0x%+B\",\"%ld\"\n",
+				CREATE, uid, family, init, resp, ntohl(spi_r), enc, &encr_i,
+				integ, &integ_i, child_sa->get_lifetime(child_sa, TRUE));
+    int res2 = fprintf(this->f,
+        		"\"%s\",\"%u\",\"%s\",\"%H\",\"%H\",\"0x%.8x\","
+				"\"%s\",\"0x%+B\",\"%s\",\"0x%+B\",\"%ld\"\n",
+				CREATE, uid, family, resp, init, ntohl(spi_i), enc, &encr_r,
+				integ, &integ_r, child_sa->get_lifetime(child_sa, TRUE));
+    if (res1 < 0 || res2 < 0) {
+    	DBG0(DBG_CHD,
+    		"Failed to write child_derived_keys to file \"%s\" for \"%ld\"",
+    		this->filepath, child_sa->get_unique_id(child_sa));
+    }
+  } else {
+    DBG1(DBG_CHD,
+         "CHILD_SA %d has %sencrption alg and has %sintegrity alg "
+         "but requires both",
+         uid, enc ? "" : "no ", integ ? "" : "no ");
+  }
+  return TRUE;
+}
+
+/**
+ * Handle SA deletion
+ */
+METHOD(listener_t, child_updown, bool, private_sa_notify_listener_t *this,
+       ike_sa_t *ike_sa, child_sa_t *child_sa, bool up) {
+  /* Only care about deletion not creation here since `child_derived_keys`
+   * handles creation */
+  if (up) {
+    return TRUE;
+  }
+  int res = fprintf(this->f, "\"%s\",\"%u\"\n", DELETE,
+			child_sa->get_unique_id(child_sa));
+  if (res < 0) {
+  	DBG0(DBG_CHD,
+    		"Failed to write child_child_updown to file \"%s\" for \"%ld\"",
+    		this->filepath, child_sa->get_unique_id(child_sa));
+  }
+  return TRUE;
+}
+
+/**
+ * Handle SA rekeying
+ */
+METHOD(listener_t, child_rekey, bool, private_sa_notify_listener_t *this,
+       ike_sa_t *ike_sa, child_sa_t *old, child_sa_t *new) {
+  int res = fprintf(this->f, "\"%s\",\"%u\",\"%ld\",\"%u\",\"%ld\"\n", REKEY,
+        	old->get_unique_id(old), old->get_lifetime(old, TRUE),
+        	new->get_unique_id(new), new->get_lifetime(new, TRUE));
+  if (res < 0) {
+  	DBG0(DBG_CHD,
+    		"Failed to write child_rekey to file \"%s\" for old: \"%ld\" new: \"%ld\"",
+    		this->filepath, old->get_unique_id(old), new->get_unique_id(new));
+  }
+  return TRUE;
+}
+
+METHOD(sa_notify_listener_t, destroy, void,
+       private_sa_notify_listener_t *this) {
+  fclose(this->f);
+  free(this);
+}
+
+sa_notify_listener_t *sa_notify_listener_create() {
+	private_sa_notify_listener_t *this;
+
+	INIT(this,
+		.public = {
+			.listener = {
+				.child_derived_keys = _child_derived_keys,
+				.child_updown = _child_updown,
+				.child_rekey = _child_rekey,
+			},
+			.destroy = _destroy,
+		},
+		.filepath = lib->settings->get_str(
+			lib->settings, "%s.plugins.sa-notify.child_sa", NULL, lib->ns),
+	);
+
+
+  this->f = fopen(this->filepath, "a");
+  if (!this->f) {
+    DBG0(DBG_DMN, "Failed to open file: %s", this->filepath);
+  }
+
+  return &this->public;
+}

--- a/src/libcharon/plugins/sa_notify/sa_notify_listener.h
+++ b/src/libcharon/plugins/sa_notify/sa_notify_listener.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Christopher Chon
+ * Nefeli Networks Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef SA_NOTIFY_LISTENER_H_
+#define SA_NOTIFY_LISTENER_H_
+
+#include <bus/listeners/listener.h>
+
+typedef struct sa_notify_listener_t sa_notify_listener_t;
+
+/**
+ * Listens for IKEv2 and CHILD SA creation, rekeying, and deletion.
+ */
+struct sa_notify_listener_t {
+
+	/**
+	 * Implements listener_t interface
+	 */
+	listener_t listener;
+
+	/**
+	 * Destroy a sa_notify_listener_t
+	 */
+ 	void (*destroy)(sa_notify_listener_t *this);
+};
+
+/**
+ * Create a sa_notify_listener instance
+ */
+sa_notify_listener_t *sa_notify_listener_create();
+
+#endif /** SA_NOTIFY_LISTENER_H_ @} */

--- a/src/libcharon/plugins/sa_notify/sa_notify_plugin.c
+++ b/src/libcharon/plugins/sa_notify/sa_notify_plugin.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2018 Christopher Chon
+ * Nefeli Networks Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "sa_notify_plugin.h"
+#include "sa_notify_listener.h"
+
+#include <daemon.h>
+
+typedef struct private_sa_notify_plugin_t private_sa_notify_plugin_t;
+
+/**
+ * Private data
+ */
+struct private_sa_notify_plugin_t {
+
+	/**
+	 * Public interface
+	 */
+	sa_notify_plugin_t public;
+
+	/**
+	 * Listener implementation
+	 */
+	sa_notify_listener_t *listener;
+};
+
+METHOD(plugin_t, get_name, char *, private_sa_notify_plugin_t *this) {
+	return "sa_notify";
+}
+
+/**
+ * Register listener
+ */
+static bool plugin_cb(private_sa_notify_plugin_t *this,
+							plugin_feature_t *feature, bool reg, void *cb_data)
+{
+	if (reg)
+	{
+		charon->bus->add_listener(charon->bus, &this->listener->listener);
+	}
+	else
+	{
+		charon->bus->remove_listener(charon->bus, &this->listener->listener);
+	}
+	return TRUE;
+}
+
+METHOD(plugin_t, get_features, int, private_sa_notify_plugin_t *this,
+			 plugin_feature_t *features[])
+{
+	static plugin_feature_t f[] =
+	{
+			PLUGIN_CALLBACK((plugin_feature_callback_t)plugin_cb, NULL),
+			PLUGIN_PROVIDE(CUSTOM, "sa_notify"),
+	};
+	*features = f;
+	return countof(f);
+}
+
+METHOD(plugin_t, destroy, void, private_sa_notify_plugin_t *this)
+{
+	this->listener->destroy(this->listener);
+	free(this);
+}
+
+plugin_t *sa_notify_plugin_create()
+{
+	private_sa_notify_plugin_t *this;
+
+	INIT(this,
+			.public = {
+				.plugin = {
+					.get_name = _get_name,
+					.get_features = _get_features,
+					.destroy = _destroy,
+				},
+			},
+			.listener = sa_notify_listener_create(),
+	);
+
+	return &this->public.plugin;
+}

--- a/src/libcharon/plugins/sa_notify/sa_notify_plugin.h
+++ b/src/libcharon/plugins/sa_notify/sa_notify_plugin.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 Christopher Chon
+ * Nefeli Networks Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * @defgroup sa_notify sa_notify
+ * @ingroup cplugins
+ *
+ * @defgroup sa_notify_plugin sa_notify_plugin
+ * @{ @ingroup sa_notify
+ */
+
+#ifndef SA_NOTIFY_PLUGIN_H_
+#define SA_NOTIFY_PLUGIN_H_
+
+#include <plugins/plugin.h>
+
+typedef struct sa_notify_plugin_t sa_notify_plugin_t;
+
+/**
+ * Plugin that writes IKEv2 and CHILD SA creation, rekeying, and deletion to a
+ * file.
+ */
+struct sa_notify_plugin_t {
+
+  /**
+   * Implements plugin_t interface.
+   */
+  plugin_t plugin;
+};
+
+#endif /** SA_NOTIFY_PLUGIN_H_ @} */


### PR DESCRIPTION
Adds a plugin based on the `save-keys` plugin. `sa-notify` appends create, delete, and rekey events for all CHILD_SA to a file and closes the file on plugin teardown. For reference, here's the [commits for `save-keys`](https://github.com/strongswan/strongswan/commits/master/src/libcharon/plugins/save_keys)